### PR TITLE
Added Dedicated Server page

### DIFF
--- a/markdown/internal/dedicated-server.md
+++ b/markdown/internal/dedicated-server.md
@@ -12,19 +12,16 @@ For everyone else, you will need to download the [Assets](https://github.com/nzp
 ### Defining a Port
 You would use the `sv_port_tcp` cvar to specify which port the **WS** server will run on.
 ### Protocol Name
-`NZP-REBOOT-WEB`
+`com_protocolname` = `NZP-REBOOT-WEB`
 
 The dedicated server runs a websocket server, you will need to type explicitly `connect ws://ip:port` into your console on an HTTP (**not S**) page of the web client otherwise the browser will block the connection.
 
 
 ## Desktop/Native
 ### Defining a Port
-**Request for Clarification**: What protocol does it use over UDP? Based on CVars, I saw the `sv_protocol` accepts ONLY the value CSQC which is Client Side QuakeC but that doesn't make sense for a dedicated server? Does it?
-
-
 You would use the `sv_port` cvar to specify which port the **UDP** server will run on.
 ### Protocol Name
-`NZP-REBOOT`
+`com_protocolname` = `NZP-REBOOT`
 
 ### Custom Tick Rates
 `sv_mintic` is how frequently (in seconds) physics frames are calculated. The default value is 0.045, every 45 milliseconds, it calculates the physics. Be careful with raising this value too high as the more times per second the physics are calculated, the more packets are sent out and can be very bandwidth intensive, this becomes more apparent at higher rounds. With that being said though, 0.045 may be too high/slow and can lead to some physics issues such as zombies getting stuck on the ground/terrain, unable to climb stairs (observed on NDU), etc.

--- a/markdown/internal/dedicated-server.md
+++ b/markdown/internal/dedicated-server.md
@@ -1,0 +1,30 @@
+% Dedicated Server - NZ:P Internal Documentation
+# Dedicated Server
+## Binary
+You will want to obtain the upstream [FTEQW](https://www.fteqw.org/) server binary for your respective platform.
+
+If you run pterodactyl there is an [egg](https://github.com/JordanPlayz158/games-standalone/blob/add/nazi-zombies-portable/nazi_zombies_portable/egg-nazi-zombies--portable.json) <!-- Replace with link to official repo once merged --> that handles the Binary, Assets, QuakeC, and CVars for you.
+
+For everyone else, you will need to download the [Assets](https://github.com/nzp-team/assets/releases) and [QuakeC](https://github.com/nzp-team/quakec/releases) files when using upstream FTEQW. For assets, you will want to download `pc-nzp-assets.zip` and extract it to the same location as the binary, you should have the FTEQW binary and a directory called `nzp` beside it. For QuakeC you will want both `fte-nzp-qc.zip` and `standard-nzp-qc.zip` and you will want to extract them inside the `nzp` folder. The NZP folder should now contain some `.dat` files. After that, you can run the binary with the `-dedicated` argument and with the below [cvars](https://fte.triptohell.info/wiki/index.php/Console_Variables) outlined.
+
+
+## Web
+### Defining a Port
+You would use the `sv_port_tcp` cvar to specify which port the **WS** server will run on.
+### Protocol Name
+`NZP-REBOOT-WEB`
+
+The dedicated server runs a websocket server, you will need to type explicitly `connect ws://ip:port` into your console on an HTTP (**not S**) page of the web client otherwise the browser will block the connection.
+
+
+## Desktop/Native
+### Defining a Port
+**Request for Clarification**: What protocol does it use over UDP? Based on CVars, I saw the `sv_protocol` accepts ONLY the value CSQC which is Client Side QuakeC but that doesn't make sense for a dedicated server? Does it?
+
+
+You would use the `sv_port` cvar to specify which port the **UDP** server will run on.
+### Protocol Name
+`NZP-REBOOT`
+
+### Custom Tick Rates
+`sv_mintic` is how frequently (in seconds) physics frames are calculated. The default value is 0.045, every 45 milliseconds, it calculates the physics. Be careful with raising this value too high as the more times per second the physics are calculated, the more packets are sent out and can be very bandwidth intensive, this becomes more apparent at higher rounds. With that being said though, 0.045 may be too high/slow and can lead to some physics issues such as zombies getting stuck on the ground/terrain, unable to climb stairs (observed on NDU), etc.

--- a/markdown/landing/index.md
+++ b/markdown/landing/index.md
@@ -20,6 +20,8 @@ All documentation and media hosted is licensed under CC-BY-SA 4.0, with no exclu
 
 At this current moment, no marked-stable builds of Nazi Zombies: Portable are made available. Instead, nightly builds on all platforms are released via GitHub releases, accessible [here](https://github.com/nzp-team/nzportable/releases/latest). This link will always take you to the latest release, identifiable via the build date in the release title.
 
+If you wish to setup a Dedicated Server for Nazi Zombies: Portable, [click here](../internal/dedicated-server.md)
+
 ## Core Documentation
 
 Core documents contain information about Nazi Zombies: Portable's internal design. They are not specifically relevant to custom content creators, though overlap will be present for map features that interact with NZ:P's QuakeC.

--- a/markdown/landing/index.md
+++ b/markdown/landing/index.md
@@ -20,12 +20,11 @@ All documentation and media hosted is licensed under CC-BY-SA 4.0, with no exclu
 
 At this current moment, no marked-stable builds of Nazi Zombies: Portable are made available. Instead, nightly builds on all platforms are released via GitHub releases, accessible [here](https://github.com/nzp-team/nzportable/releases/latest). This link will always take you to the latest release, identifiable via the build date in the release title.
 
-If you wish to setup a Dedicated Server for Nazi Zombies: Portable, [click here](../internal/dedicated-server.md)
-
 ## Core Documentation
 
 Core documents contain information about Nazi Zombies: Portable's internal design. They are not specifically relevant to custom content creators, though overlap will be present for map features that interact with NZ:P's QuakeC.
 
+- [Dedicated Server](../internal/dedicated-server.md)
 - [Weapon IDs](../internal/weapon-ids.md)
 
 ## Mapping & Modding Documentation


### PR DESCRIPTION
This is the mostly done Dedicated server page based on suggestions, although it does have 1 link to be changed once egg is merged into pterodactyl (https://github.com/pelican-eggs/games-standalone/pull/18) and request for clarification for the udp protocol which you can see in the md source.