### PR TITLE
Fixed the issues with the dedicated server page brought up by Cypress in the discord

### DIFF
--- a/markdown/internal/dedicated-server.md
+++ b/markdown/internal/dedicated-server.md
@@ -3,7 +3,7 @@
 ## Binary
 You will want to obtain the upstream [FTEQW](https://www.fteqw.org/) server binary for your respective platform.
 
-If you run pterodactyl there is an [egg](https://github.com/JordanPlayz158/games-standalone/blob/add/nazi-zombies-portable/nazi_zombies_portable/egg-nazi-zombies--portable.json) <!-- Replace with link to official repo once merged --> that handles the Binary, Assets, QuakeC, and CVars for you.
+If you run pterodactyl there is an [egg](https://github.com/pelican-eggs/games-standalone/tree/main/nazi_zombies_portable) that handles the Binary, Assets, QuakeC, and CVars for you.
 
 For everyone else, you will need to download the [Assets](https://github.com/nzp-team/assets/releases) and [QuakeC](https://github.com/nzp-team/quakec/releases) files when using upstream FTEQW. For assets, you will want to download `pc-nzp-assets.zip` and extract it to the same location as the binary, you should have the FTEQW binary and a directory called `nzp` beside it. For QuakeC you will want both `fte-nzp-qc.zip` and `standard-nzp-qc.zip` and you will want to extract them inside the `nzp` folder. The NZP folder should now contain some `.dat` files. After that, you can run the binary with the `-dedicated` argument and with the below [cvars](https://fte.triptohell.info/wiki/index.php/Console_Variables) outlined.
 
@@ -11,6 +11,7 @@ For everyone else, you will need to download the [Assets](https://github.com/nzp
 ## Web
 ### Defining a Port
 You would use the `sv_port_tcp` cvar to specify which port the **WS** server will run on.
+
 ### Protocol Name
 `com_protocolname` = `NZP-REBOOT-WEB`
 
@@ -20,6 +21,7 @@ The dedicated server runs a websocket server, you will need to type explicitly `
 ## Desktop/Native
 ### Defining a Port
 You would use the `sv_port` cvar to specify which port the **UDP** server will run on.
+
 ### Protocol Name
 `com_protocolname` = `NZP-REBOOT`
 


### PR DESCRIPTION
I was informed of 2 issues with the current dedicated server page [here](https://discord.com/channels/1182081152073351228/1187590268120203304/1294047192461607002) and [here](https://discord.com/channels/1182081152073351228/1187590268120203304/1294049452595871757) which were about the invalid link to the nazi zombies portable pterodactyl/pelican egg and the formatting of the protocol name header and content being incorrect (not properly rendering on their own line and bleeded in at the end of the "Defining a Port" section). Both of these issues have been fixed in this PR.