### PR TITLE
`waypointing.md`: Clarity and spelling fixes

### DIFF
--- a/markdown/mapping/waypointing.md
+++ b/markdown/mapping/waypointing.md
@@ -7,29 +7,29 @@
 
 _Nazi Zombies: Portable_ makes use of a waypointing system to define nodes that zombies may path between. This allows for a fairly simple and intuitive, albeit limited, way to allow mappers to create custom pathfinding for their maps.
 
-Waypoints are edited directly in-game via a special Waypoint Mode, as opposed to creating them in the map editor. This mode can be accessed via `waypoint_mode` cvar.
+Waypoints are edited directly in-game via a special Waypoint Mode, as opposed to creating them in the map editor. This mode can be accessed by setting the `waypoint_mode` cvar or with `impulse 100`.
 Saving a set of waypoints via this mode will generate a `.way` file within the maps folder of NZ:P, matching the original map file name. This `.way` file must be supplied alongside the original map file when sharing maps.
 
 ![Waypoint Mode UI with waypoint nodes visible.](../res/images/waypoint_mode.webp)
 
 ## .way Files
 
-Due to `.way` files being plain-text, they can be opened in any text editor. Doing so will reveal the following data structure:
+Once created, the `.way` file is a plain-text format and may be opened in any text editor. Doing so will reveal the following data structure:
 
 ![Data structure of a `.way` file when opened in a text editor.](../res/images/waypoint_plain_text.webp)
 
 | Data Identifier | Description |
 |---|---| 
-| Origin | The co-ordinates of the waypoint node. | 
-| ID | The numerical identifier of the waypoint node. |
-| Special | The associated `wayTarget` ID of a valid `nzp_func_door` that has been correctly linked to the waypoint node. | 
-| Target 1-8 | 8 Possible waypoint nodes that are connected to the waypoint node. | 
+| `origin` | The coordinates of the waypoint node. | 
+| `id` | The numerical identifier of the waypoint node. |
+| `special` | The associated `wayTarget` ID of a valid `nzp_func_door` that has been correctly linked to the waypoint node. | 
+| `target[1-8]` | The ID of up to eight possible waypoint nodes that are connected to the waypoint node. | 
 
-Up to 256 total nodes are supported at this time. Additionally, when a node is deleted within waypoint mode, the ID it occupied within the `.way` will not be freed up for use by following nodes as they are created. This can be remidied by manually reassigning ID's via opening the file in a text editor.
+Up to 256 total nodes are supported at this time. Additionally, when a node is deleted within waypoint mode, the ID it occupied within the `.way` will not be freed up for use by following nodes as they are created. This can be remedied by manually reassigning IDs via opening the file in a text editor.
 
 ## Interacting with Waypoints
 
-![(Left to right) Blue-Default, Yellow-Selected, Red-Linked to Current, Special-Used for Doors (Same 3 colours as previous). ](../res/images/waypoint_types.webp)
+![(Left to right) Blue-Default, Yellow-Selected, Red-Linked to Current, Special-Used for Doors (same 3 colors as previous). ](../res/images/waypoint_types.webp)
 
 | Actions | Description |
 |---|---| 
@@ -45,13 +45,12 @@ Up to 256 total nodes are supported at this time. Additionally, when a node is d
 Special Waypoint nodes are used in conjunction with a valid `func_nzp_door` to prevent zombies from attempting to path through currently closed doors.
 
 A valid `func_nzp_door` requires an ID to be set in the `wayTarget` entity field. Targetting this `wayTarget` within waypoint mode is done via placing a waypoint node within the door entity you have created, and creating a special entity
-whilst this node is selected. Correct use of this function can be clarifyed by a console output.
+whilst this node is selected. Correct use of this function can be clarified by console output.
 
-## Pathing Behaviour
+## Pathing Behavior
 
-Zombies will move along a path dictated by the mapper through connected waypoint nodes until they are within sight range to path to a player on their own (Where "Sight" is dictated by both the zombies shins, chest and forehead being able to see the player).
+Zombies will move along a path dictated by the mapper through connected waypoint nodes until they are within sight range to path to a player on their own (where "sight" is dictated by both the zombies shins, chest and forehead being able to see the player).
 
-When zombies reacquire a path to the player (Whether that be after hopping a barricade post-spawn, or in attempt to find the player after they have teleported outside and back into the map.), 
-they will do so via the closest waypoint node to them. There is however a heuristic cost, meaning zombies will attempt different paths via alternate nodes if the closest node to them is not reachable.
+When zombies reacquire a path to the player (whether that be after hopping a barricade post-spawn, or in attempt to find the player after they have teleported outside and back into the map), they will do so via the closest waypoint node to them. There is however a heuristic cost, meaning zombies will attempt different paths via alternate nodes if the closest node to them is not reachable.
 
 ![Example map of connected waypoint nodes, arrows indicating that nodes are linked in both directions.](../res/images/example_waypoints.webp)

--- a/markdown/mapping/waypointing.md
+++ b/markdown/mapping/waypointing.md
@@ -7,7 +7,7 @@
 
 _Nazi Zombies: Portable_ makes use of a waypointing system to define nodes that zombies may path between. This allows for a fairly simple and intuitive, albeit limited, way to allow mappers to create custom pathfinding for their maps.
 
-Waypoints are edited directly in-game via a special Waypoint Mode, as opposed to creating them in the map editor. This mode can be accessed by setting the `waypoint_mode` cvar or with `impulse 100`.
+Waypoints are edited directly in-game via a special Waypoint Mode, as opposed to creating them in the map editor. This mode can be accessed by setting the `waypoint_mode` cvar and restarting the level.
 Saving a set of waypoints via this mode will generate a `.way` file within the maps folder of NZ:P, matching the original map file name. This `.way` file must be supplied alongside the original map file when sharing maps.
 
 ![Waypoint Mode UI with waypoint nodes visible.](../res/images/waypoint_mode.webp)


### PR DESCRIPTION
I made some edits to F0mx's waypointing page that tidies up the grammar and spelling as well as making the page more clear. They're minor, but should be sufficient to close nzp-team/nzportable#1174.