### PR TITLE
Don't convert external markdown to .html links

### DIFF
--- a/links-to-html.lua
+++ b/links-to-html.lua
@@ -1,4 +1,6 @@
 function Link(el)
-    el.target = string.gsub(el.target, "%.md", ".html")
+    if not el.target:match("^https?://") then
+      el.target = el.target:gsub("%.md$", ".html")
+    end
     return el
   end


### PR DESCRIPTION
Fixes an issue where currently the Toolbox page has ".html" links for the NZ:P Toolbox README, which itself is .md, not .html, which causes a 404 error.


https://github.com/user-attachments/assets/80286fc6-1bb8-4dfd-90c8-d54b56041b9a

